### PR TITLE
Covered explicitely whitelisted postcodes

### DIFF
--- a/spec/cassettes/PostcodeChecker_AccessControlService/when_explicitely_whitelisted/is_truthful.yml
+++ b/spec/cassettes/PostcodeChecker_AccessControlService/when_explicitely_whitelisted/is_truthful.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.postcodes.io/postcodes/AAA012
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - postcode_checker/v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx/1.14.0
+      Date:
+      - Fri, 06 Mar 2020 15:05:39 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '41'
+      Connection:
+      - keep-alive
+      X-Gnu:
+      - Michael J Blanchard
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"29-T14TWaKfjMuMFPoRgcsDj2g1ORs"
+    body:
+      encoding: UTF-8
+      string: '{"status":404,"error":"Invalid postcode"}'
+    http_version: null
+  recorded_at: Fri, 06 Mar 2020 15:05:39 GMT
+recorded_with: VCR 5.1.0

--- a/spec/cassettes/PostcodeChecker_AccessControlService/when_explicitely_whitelisted/is_untruthful.yml
+++ b/spec/cassettes/PostcodeChecker_AccessControlService/when_explicitely_whitelisted/is_untruthful.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.postcodes.io/postcodes/AAA012
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - postcode_checker/v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx/1.14.0
+      Date:
+      - Fri, 06 Mar 2020 15:03:46 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '41'
+      Connection:
+      - keep-alive
+      X-Gnu:
+      - Michael J Blanchard
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"29-T14TWaKfjMuMFPoRgcsDj2g1ORs"
+    body:
+      encoding: UTF-8
+      string: '{"status":404,"error":"Invalid postcode"}'
+    http_version: null
+  recorded_at: Fri, 06 Mar 2020 15:03:46 GMT
+recorded_with: VCR 5.1.0

--- a/spec/cassettes/PostcodeChecker_AccessControlService/when_not_in_whitelist/is_untruthful.yml
+++ b/spec/cassettes/PostcodeChecker_AccessControlService/when_not_in_whitelist/is_untruthful.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.postcodes.io/postcodes/XYZ210
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - postcode_checker/v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx/1.14.0
+      Date:
+      - Fri, 06 Mar 2020 15:05:40 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '41'
+      Connection:
+      - keep-alive
+      X-Gnu:
+      - Michael J Blanchard
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"29-T14TWaKfjMuMFPoRgcsDj2g1ORs"
+    body:
+      encoding: UTF-8
+      string: '{"status":404,"error":"Invalid postcode"}'
+    http_version: null
+  recorded_at: Fri, 06 Mar 2020 15:05:40 GMT
+recorded_with: VCR 5.1.0

--- a/spec/cassettes/PostcodeChecker_AccessControlService/when_outside_service_area/is_untruthful.yml
+++ b/spec/cassettes/PostcodeChecker_AccessControlService/when_outside_service_area/is_untruthful.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.postcodes.io/postcodes/AAA012
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - postcode_checker/v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx/1.14.0
+      Date:
+      - Fri, 06 Mar 2020 14:56:59 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '41'
+      Connection:
+      - keep-alive
+      X-Gnu:
+      - Michael J Blanchard
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"29-T14TWaKfjMuMFPoRgcsDj2g1ORs"
+    body:
+      encoding: UTF-8
+      string: '{"status":404,"error":"Invalid postcode"}'
+    http_version: null
+  recorded_at: Fri, 06 Mar 2020 14:56:59 GMT
+recorded_with: VCR 5.1.0

--- a/spec/cassettes/PostcodeChecker_AccessControlService/when_within_service_area_LSOA/is_truthful.yml
+++ b/spec/cassettes/PostcodeChecker_AccessControlService/when_within_service_area_LSOA/is_truthful.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.postcodes.io/postcodes/e143qp
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - postcode_checker/v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.14.0
+      Date:
+      - Fri, 06 Mar 2020 14:56:02 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '810'
+      Connection:
+      - keep-alive
+      X-Gnu:
+      - Michael J Blanchard
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"32a-AAtMJkUe5GlwLQ8QW/yjn7GnJbU"
+    body:
+      encoding: UTF-8
+      string: '{"status":200,"result":{"postcode":"E14 3QP","quality":1,"eastings":537556,"northings":178565,"country":"England","nhs_ha":"London","longitude":-0.020114,"latitude":51.489309,"european_electoral_region":"London","primary_care_trust":"Tower
+        Hamlets","region":"London","lsoa":"Tower Hamlets 031B","msoa":"Tower Hamlets
+        031","incode":"3QP","outcode":"E14","parliamentary_constituency":"Poplar and
+        Limehouse","admin_district":"Tower Hamlets","parish":"Tower Hamlets, unparished
+        area","admin_county":null,"admin_ward":"Island Gardens","ced":null,"ccg":"NHS
+        Tower Hamlets","nuts":"Tower Hamlets","codes":{"admin_district":"E09000030","admin_county":"E99999999","admin_ward":"E05009324","parish":"E43000220","parliamentary_constituency":"E14000882","ccg":"E38000186","ccg_id":"08V","ced":"E99999999","nuts":"UKI42"}}}'
+    http_version: null
+  recorded_at: Fri, 06 Mar 2020 14:56:02 GMT
+recorded_with: VCR 5.1.0

--- a/spec/cassettes/PostcodeChecker_AccessControlService/when_within_service_area_postcodes/is_truthful.yml
+++ b/spec/cassettes/PostcodeChecker_AccessControlService/when_within_service_area_postcodes/is_truthful.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.postcodes.io/postcodes/E10ND
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - postcode_checker/v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.14.0
+      Date:
+      - Fri, 06 Mar 2020 14:56:58 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '807'
+      Connection:
+      - keep-alive
+      X-Gnu:
+      - Michael J Blanchard
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"327-RqSrSU0Z8FQkLy4ASsljnBfRAxo"
+    body:
+      encoding: UTF-8
+      string: '{"status":200,"result":{"postcode":"E1 0ND","quality":1,"eastings":536059,"northings":181242,"country":"England","nhs_ha":"London","longitude":-0.040631,"latitude":51.513727,"european_electoral_region":"London","primary_care_trust":"Tower
+        Hamlets","region":"London","lsoa":"Tower Hamlets 019C","msoa":"Tower Hamlets
+        019","incode":"0ND","outcode":"E1","parliamentary_constituency":"Bethnal Green
+        and Bow","admin_district":"Tower Hamlets","parish":"Tower Hamlets, unparished
+        area","admin_county":null,"admin_ward":"St Dunstan''s","ced":null,"ccg":"NHS
+        Tower Hamlets","nuts":"Tower Hamlets","codes":{"admin_district":"E09000030","admin_county":"E99999999","admin_ward":"E05009329","parish":"E43000220","parliamentary_constituency":"E14000555","ccg":"E38000186","ccg_id":"08V","ced":"E99999999","nuts":"UKI42"}}}'
+    http_version: null
+  recorded_at: Fri, 06 Mar 2020 14:56:58 GMT
+recorded_with: VCR 5.1.0

--- a/spec/fixtures/whitelist.yaml
+++ b/spec/fixtures/whitelist.yaml
@@ -1,4 +1,5 @@
 lsoas:
   - Tower Hamlets
 postcodes: 
-  - e143qe
+  - e10nd
+  - aaa012

--- a/spec/postcode_checker/access_control_service_spec.rb
+++ b/spec/postcode_checker/access_control_service_spec.rb
@@ -1,20 +1,14 @@
 # frozen_string_literal: true
 
-describe PostcodeChecker::AccessControlService do
+describe PostcodeChecker::AccessControlService, :vcr do
   let(:service) do
     described_class.call(
-      postcode: postcode, whitelist_file_path: whitelist_file_path
+      postcode_string: postcode_string, whitelist_file_path: whitelist_file_path
     )
   end
 
   context 'when within service area LSOA' do
-    let(:postcode) do
-      { 'status' => 200,
-        'result' => {
-          'lsoa' => 'Tower Hamlets 031A',
-          'postcode' => 'AAA 012'
-        } }
-    end
+    let(:postcode_string) { 'e143qp' }
     let(:whitelist_file_path) do
       File.join(__dir__, '../fixtures', 'whitelist.yaml')
     end
@@ -25,13 +19,7 @@ describe PostcodeChecker::AccessControlService do
   end
 
   context 'when within service area postcodes' do
-    let(:postcode) do
-      { 'status' => 200,
-        'result' => {
-          'lsoa' => 'Whatever',
-          'postcode' => 'E14 3QE'
-        } }
-    end
+    let(:postcode_string) { 'E1 0ND' }
     let(:whitelist_file_path) do
       File.join(__dir__, '../fixtures', 'whitelist.yaml')
     end
@@ -41,14 +29,19 @@ describe PostcodeChecker::AccessControlService do
     end
   end
 
-  context 'when outside service area' do
-    let(:postcode) do
-      { 'status' => 200,
-        'result' => {
-          'lsoa' => 'Whatever',
-          'postcode' => 'AAA 012'
-        } }
+  context 'when explicitely whitelisted' do
+    let(:postcode_string) { 'AAA 012' }
+    let(:whitelist_file_path) do
+      File.join(__dir__, '../fixtures', 'whitelist.yaml')
     end
+
+    it 'is truthful' do
+      expect(service).to be_truthy
+    end
+  end
+
+  context 'when not in whitelist' do
+    let('postcode_string') { 'XYZ 210' }
     let(:whitelist_file_path) do
       File.join(__dir__, '../fixtures', 'whitelist.yaml')
     end


### PR DESCRIPTION
Covers explicitely whitelisted postcodes that are not covered by `postcodes.io` API